### PR TITLE
fix broken link

### DIFF
--- a/tutorials.md
+++ b/tutorials.md
@@ -9,7 +9,7 @@ title: Tutorials
 * Will be replaced with the ToC, excluding the "Contents" header
 {:toc}-->
 
-* [Tutorial on code optimisation and profiling in R by Maxime Turgeon](http://turgeonmaxime.github.io/optimisation/)
+* [Tutorial on code optimisation and profiling in R by Maxime Turgeon](http://turgeonmaxime.github.io/optimisation)
 * [Introduction to Genomic Ranges `R` objects Presentation by Greg Voisin](/tutorials/granges/granges-tutorial-presentation.html)  
 [source](https://raw.githubusercontent.com/GreenwoodLab/GreenwoodLab.github.io/master/tutorials/granges/granges-tutorial-presentation.Rpres)
 * [Introduction to Genomic Ranges `R` objects Vignette by Greg Voisin](/tutorials/granges/granges-tutorial.html)  


### PR DESCRIPTION
The link for the optimisation tutorial was not working properly, because of a trailing slash. I fixed it.
